### PR TITLE
Add zb_subscriber and its macros

### DIFF
--- a/include/zbus.h
+++ b/include/zbus.h
@@ -98,6 +98,25 @@ typedef enum __attribute__((packed)) {
         val, ##__VA_ARGS__ \
     }
 
+#define ZB_SUBSCRIBER_REGISTER(name, queue_size)                        \
+    K_MSGQ_DEFINE(name##_queue, sizeof(zb_channel_index_t), queue_size, \
+                  sizeof(zb_channel_index_t));                          \
+    struct zb_subscriber name = {                                       \
+        .queue    = &name##_queue,                                      \
+        .callback = NULL,                                               \
+    }
+
+#define ZB_SUBSCRIBER_REGISTER_CALLBACK(name, cb) \
+    struct zb_subscriber name = {                 \
+        .queue    = NULL,                         \
+        .callback = cb,                           \
+    }
+
+struct zb_subscriber {
+    struct k_msgq *queue;
+    void (*callback)(void);
+};
+
 struct metadata {
     struct {
         bool pend_callback;
@@ -109,7 +128,7 @@ struct metadata {
     uint16_t message_size;
     uint8_t *message;
     struct k_sem *semaphore;
-    struct k_msgq **subscribers;
+    struct zb_subscriber **subscribers;
 };
 
 #undef ZB_CHANNEL

--- a/tests/extension/include/zbus_channels.h
+++ b/tests/extension/include/zbus_channels.h
@@ -1,36 +1,36 @@
-ZB_CHANNEL(version,                             /* Name */
-           false,                               /* Persistent */
-           false,                               /* On changes only */
-           true,                                /* Read only */
-           struct version,                      /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES_EMPTY, /* Subscribers */
+ZB_CHANNEL(version,                      /* Name */
+           false,                        /* Persistent */
+           false,                        /* On changes only */
+           true,                         /* Read only */
+           struct version,               /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS_EMPTY, /* Subscribers */
            ZB_INIT(.major = 0, .minor = 1,
                    .build = 1023) /* Initial value major 0, minor 1, build 1023 */
 )
 
-ZB_CHANNEL(sensor_data,                         /* Name */
-           true,                                /* Persistent */
-           true,                                /* On changes only */
-           false,                               /* Read only */
-           struct sensor_data,                  /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES_EMPTY, /* Subscribers */
-           ZB_INIT(0)                           /* Initial value {0} */
+ZB_CHANNEL(sensor_data,                  /* Name */
+           true,                         /* Persistent */
+           true,                         /* On changes only */
+           false,                        /* Read only */
+           struct sensor_data,           /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS_EMPTY, /* Subscribers */
+           ZB_INIT(0)                    /* Initial value {0} */
 )
 
-ZB_CHANNEL(start_measurement,                               /* Name */
-           false,                                           /* Persistent */
-           false,                                           /* On changes only */
-           false,                                           /* Read only */
-           struct action,                                   /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES(peripheral_queue), /* Subscribers */
-           ZB_INIT(false)                                   /* Initial value */
+ZB_CHANNEL(start_measurement,                  /* Name */
+           false,                              /* Persistent */
+           false,                              /* On changes only */
+           false,                              /* Read only */
+           struct action,                      /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS(peripheral), /* Subscribers */
+           ZB_INIT(false)                      /* Initial value */
 )
 
-ZB_CHANNEL(finish,                              /* Name */
-           false,                               /* Persistent */
-           false,                               /* On changes only */
-           false,                               /* Read only */
-           struct action,                       /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES_EMPTY, /* Subscribers */
-           ZB_INIT(false)                       /* Initial value */
+ZB_CHANNEL(finish,                       /* Name */
+           false,                        /* Persistent */
+           false,                        /* On changes only */
+           false,                        /* Read only */
+           struct action,                /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS_EMPTY, /* Subscribers */
+           ZB_INIT(false)                /* Initial value */
 )

--- a/tests/extension/src/core.c
+++ b/tests/extension/src/core.c
@@ -13,7 +13,7 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(core, CONFIG_ZBUS_LOG_LEVEL);
 
-K_MSGQ_DEFINE(core_queue, sizeof(zb_channel_index_t), 10, sizeof(zb_channel_index_t));
+ZB_SUBSCRIBER_REGISTER(core, 10);
 
 void core_thread(void)
 {

--- a/tests/extension/src/peripheral.c
+++ b/tests/extension/src/peripheral.c
@@ -13,14 +13,14 @@
 #include "zbus.h"
 LOG_MODULE_DECLARE(peripheral, CONFIG_ZBUS_LOG_LEVEL);
 
-K_MSGQ_DEFINE(peripheral_queue, sizeof(zb_channel_index_t), 10, 2);
+ZB_SUBSCRIBER_REGISTER(peripheral, 16);
 
 
 void peripheral_thread(void)
 {
     struct sensor_data sd  = {0, 0};
     zb_channel_index_t idx = 0;
-    while (!k_msgq_get(&peripheral_queue, &idx, K_FOREVER)) {
+    while (!k_msgq_get(peripheral.queue, &idx, K_FOREVER)) {
         sd.a += 1;
         sd.b += 10;
         LOG_DBG("[Peripheral] sending sensor data");

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -15,6 +15,7 @@ list(
   "${CMAKE_CURRENT_SOURCE_DIR}/src/main.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/net.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/peripheral.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/critical.c"
   )
 
 include_directories(${HEADERS})

--- a/tests/integration/include/zbus_channels.h
+++ b/tests/integration/include/zbus_channels.h
@@ -1,36 +1,36 @@
-ZB_CHANNEL(version,                       /* Name */
-           false,                         /* Persistent */
-           false,                         /* On changes only */
-           true,                          /* Read only */
-           struct version,                /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES_EMPTY, /* Subscribers */
+ZB_CHANNEL(version,                      /* Name */
+           false,                        /* Persistent */
+           false,                        /* On changes only */
+           true,                         /* Read only */
+           struct version,               /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS_EMPTY, /* Subscribers */
            ZB_INIT(.major = 0, .minor = 1,
                    .build = 1023) /* Initial value major 0, minor 1, build 1023 */
 )
 
-ZB_CHANNEL(sensor_data,                               /* Name */
-           true,                                      /* Persistent */
-           true,                                      /* On changes only */
-           false,                                     /* Read only */
-           struct sensor_data,                        /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES(core_queue), /* Subscribers */
-           ZB_INIT(0)                                 /* Initial value {0} */
+ZB_CHANNEL(sensor_data,                  /* Name */
+           true,                         /* Persistent */
+           true,                         /* On changes only */
+           false,                        /* Read only */
+           struct sensor_data,           /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS(core), /* Subscribers */
+           ZB_INIT(0)                    /* Initial value {0} */
 )
 
-ZB_CHANNEL(net_pkt,                                  /* Name */
-           false,                                    /* Persistent */
-           true,                                     /* On changes only */
-           false,                                    /* Read only */
-           struct net_pkt,                           /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES(net_queue), /* Subscribers */
-           ZB_INIT(.y = false, .x = ' ')             /* Initial value */
+ZB_CHANNEL(net_pkt,                      /* Name */
+           false,                        /* Persistent */
+           true,                         /* On changes only */
+           false,                        /* Read only */
+           struct net_pkt,               /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS(net),  /* Subscribers */
+           ZB_INIT(.y = false, .x = ' ') /* Initial value */
 )
 
-ZB_CHANNEL(start_measurement,                               /* Name */
-           false,                                           /* Persistent */
-           false,                                           /* On changes only */
-           false,                                           /* Read only */
-           struct action,                                   /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES(peripheral_queue), /* Subscribers */
-           ZB_INIT(false)                                   /* Initial value */
+ZB_CHANNEL(start_measurement,                            /* Name */
+           false,                                        /* Persistent */
+           false,                                        /* On changes only */
+           false,                                        /* Read only */
+           struct action,                                /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS(peripheral, critical), /* Subscribers */
+           ZB_INIT(false)                                /* Initial value */
 )

--- a/tests/integration/src/core.c
+++ b/tests/integration/src/core.c
@@ -13,7 +13,7 @@
 #include <logging/log.h>
 LOG_MODULE_DECLARE(core, CONFIG_ZBUS_LOG_LEVEL);
 
-K_MSGQ_DEFINE(core_queue, sizeof(zb_channel_index_t), 10, sizeof(zb_channel_index_t));
+ZB_SUBSCRIBER_REGISTER(core, 8);
 
 void core_thread(void)
 {
@@ -21,7 +21,7 @@ void core_thread(void)
     struct action start    = {true};
     zb_chan_pub(start_measurement, start, K_FOREVER);
     while (1) {
-        if (!k_msgq_get(&core_queue, &idx, K_FOREVER)) {
+        if (!k_msgq_get(core.queue, &idx, K_FOREVER)) {
             struct sensor_data data = {0};
             zb_chan_read(sensor_data, data, K_NO_WAIT);
             LOG_DBG("[Core] sensor {a = %d, b = %d}. Sending pkt", data.a, data.b);

--- a/tests/integration/src/critical.c
+++ b/tests/integration/src/critical.c
@@ -1,0 +1,10 @@
+#include <logging/log.h>
+#include "zbus.h"
+LOG_MODULE_DECLARE(peripheral, CONFIG_ZBUS_LOG_LEVEL);
+
+void urgent_callback()
+{
+    printk(" *** CRITICAL ***\n");
+}
+
+ZB_SUBSCRIBER_REGISTER_CALLBACK(critical, urgent_callback);

--- a/tests/integration/src/net.c
+++ b/tests/integration/src/net.c
@@ -13,7 +13,7 @@
 #include "zbus_messages.h"
 LOG_MODULE_REGISTER(net, CONFIG_ZBUS_LOG_LEVEL);
 
-K_MSGQ_DEFINE(net_queue, sizeof(zb_channel_index_t), 10, 2);
+ZB_SUBSCRIBER_REGISTER(net, 4);
 
 struct net_pkt pkt = {0};
 
@@ -26,7 +26,7 @@ void net_thread(void)
 {
     zb_channel_index_t idx = 0;
     while (1) {
-        if (!k_msgq_get(&net_queue, &idx, K_FOREVER)) {
+        if (!k_msgq_get(net.queue, &idx, K_FOREVER)) {
             zb_chan_read(net_pkt, pkt, K_NO_WAIT);
             LOG_DBG("[Net] Parity %c, 3 multiple: %s", pkt.x, pkt.y ? "true" : "false");
         }

--- a/tests/integration/src/peripheral.c
+++ b/tests/integration/src/peripheral.c
@@ -13,8 +13,7 @@
 #include "zbus.h"
 LOG_MODULE_DECLARE(peripheral, CONFIG_ZBUS_LOG_LEVEL);
 
-K_MSGQ_DEFINE(peripheral_queue, sizeof(zb_channel_index_t), 10, 2);
-
+ZB_SUBSCRIBER_REGISTER(peripheral, 16);
 
 void peripheral_thread(void)
 {
@@ -24,7 +23,7 @@ void peripheral_thread(void)
 
 
     zb_channel_index_t idx = 0;
-    while (!k_msgq_get(&peripheral_queue, &idx, K_FOREVER)) {
+    while (!k_msgq_get(peripheral.queue, &idx, K_FOREVER)) {
         LOG_DBG("[Peripheral] starting measurement");
         ++a;
         sd.a = a;

--- a/tests/unittests/include/zbus_channels.h
+++ b/tests/unittests/include/zbus_channels.h
@@ -1,48 +1,48 @@
 #include "zbus_messages.h"
-ZB_CHANNEL(version,                       /* Name */
-           false,                         /* Persistent */
-           false,                         /* On changes only */
-           true,                          /* Read only */
-           struct version,                /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES_EMPTY, /* Subscribers */
+ZB_CHANNEL(version,                      /* Name */
+           false,                        /* Persistent */
+           false,                        /* On changes only */
+           true,                         /* Read only */
+           struct version,               /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS_EMPTY, /* Subscribers */
            ZB_INIT(.major = 0, .minor = 1,
                    .build = 1023) /* Initial value major 0, minor 1, build 1023 */
 )
 
-ZB_CHANNEL(a,                             /* Name */
-           false,                         /* Persistent */
-           false,                         /* On changes only */
-           true,                          /* Read only */
-           struct version,                /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES_EMPTY, /* Subscribers */
-           ZB_INIT(0)                     /* Initial value major 0, minor 1, build 1023 */
+ZB_CHANNEL(a,                            /* Name */
+           false,                        /* Persistent */
+           false,                        /* On changes only */
+           true,                         /* Read only */
+           struct version,               /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS_EMPTY, /* Subscribers */
+           ZB_INIT(0)                    /* Initial value major 0, minor 1, build 1023 */
 )
 
-ZB_CHANNEL(b,                             /* Name */
-           false,                         /* Persistent */
-           false,                         /* On changes only */
-           true,                          /* Read only */
-           struct version,                /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES_EMPTY, /* Subscribers */
-           ZB_INIT(0)                     /* Initial value major 0, minor 1, build 1023 */
+ZB_CHANNEL(b,                            /* Name */
+           false,                        /* Persistent */
+           false,                        /* On changes only */
+           true,                         /* Read only */
+           struct version,               /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS_EMPTY, /* Subscribers */
+           ZB_INIT(0)                    /* Initial value major 0, minor 1, build 1023 */
 )
 
-ZB_CHANNEL(complex,                       /* Name */
-           false,                         /* Persistent */
-           false,                         /* On changes only */
-           true,                          /* Read only */
-           struct complex_msg,            /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES_EMPTY, /* Subscribers */
+ZB_CHANNEL(complex,                      /* Name */
+           false,                        /* Persistent */
+           false,                        /* On changes only */
+           true,                         /* Read only */
+           struct complex_msg,           /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS_EMPTY, /* Subscribers */
            ZB_INIT(.act = {0}, .act2 = {0},
                    .a      = {.m = 0, .field = {.a = 0, .b = 0, .c = 0}},
                    .action = 0) /* Initial value major 0, minor 1, build 1023 */
 )
 
-ZB_CHANNEL(union_complex,                 /* Name */
-           false,                         /* Persistent */
-           false,                         /* On changes only */
-           true,                          /* Read only */
-           union union_msg,               /* Message type */
-           ZB_CHANNEL_SUBSCRIBERS_QUEUES_EMPTY, /* Subscribers */
-           ZB_INIT({0})                   /* Initial value major 0, minor 1, build 1023 */
+ZB_CHANNEL(union_complex,                /* Name */
+           false,                        /* Persistent */
+           false,                        /* On changes only */
+           true,                         /* Read only */
+           union union_msg,              /* Message type */
+           ZB_CHANNEL_SUBSCRIBERS_EMPTY, /* Subscribers */
+           ZB_INIT({0})                  /* Initial value major 0, minor 1, build 1023 */
 )


### PR DESCRIPTION
- Define the zb_subcriber struct which contains the queue or callback
- Add a callback for fast/critical channel changes reaction
- Add a critical.c file to demonstrates the fast reaction working
- Adjust all tests

Signed-off-by: Rodrigo Peixoto <rodrigopex@gmail.com>